### PR TITLE
Refactor & harden import script

### DIFF
--- a/scripts/visualize-scripts/Dockerfile
+++ b/scripts/visualize-scripts/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.12
 
-RUN apk update && apk add gnupg python3 py3-requests
-
+RUN apk update && apk add gnupg python3 py3-requests py3-pip
+RUN pip install python-gnupg

--- a/scripts/visualize-scripts/http.sh
+++ b/scripts/visualize-scripts/http.sh
@@ -4,13 +4,9 @@ echo -n "Enter key passphrase: "
 read -r -s passphrase
 echo
 
-passphrasefile=$(mktemp)
-echo "$passphrase" > "$passphrasefile"
-
 echo "$passphrase" | gpg --batch --import --pinentry-mode loopback /project/keys/gpg.key
 
 es_index="http-log"
 echo "Going to import logs in Elasticsearch index $es_index"
 
-python3 ./import-logs.py "$1" "$passphrasefile" 'http://elasticsearch:9200' "$es_index" /project/data/encrypted/http/*
-rm "$passphrasefile"
+python3 ./import-logs.py "$1" "$passphrase" 'http://elasticsearch:9200' "$es_index" /project/data/encrypted/http/*

--- a/scripts/visualize-scripts/import-logs.py
+++ b/scripts/visualize-scripts/import-logs.py
@@ -94,6 +94,6 @@ if __name__ == '__main__':
 
             logging.info("Ingesting file '{}' into ES".format(ingest_path))
             es_ingest_file(ingest_path, es_host, es_index_name)
-            # print("Ingested file: {0:s}".format(filename))
+            logging.info("Succesfully ingested file: {}".format(ingest_path))
         else:
             logging.error("'{}' is not a file. Skipping".format(file_path))

--- a/scripts/visualize-scripts/import-logs.py
+++ b/scripts/visualize-scripts/import-logs.py
@@ -54,6 +54,8 @@ def decrypt_file(source_path, destination_folder, gpg_instance, passphrase):
 
 def es_ingest_file(file_path, es_host, es_index_name):
     with open(file_path, "rt") as file:
+        # Streaming multiple GB's to the ES "/_bulk" endpoint in a single request causes memory issues in ES
+        # Making one request per log-line on the other hand seems slow.
         for line in file:
             es_command = es_command_template.substitute(index_name=es_index_name, payload=line).encode('utf-8')
             headers = { 'content-type' : 'application/json' }

--- a/scripts/visualize-scripts/import-logs.py
+++ b/scripts/visualize-scripts/import-logs.py
@@ -1,37 +1,42 @@
 #!/bin/env python3
 
-import json
-import requests
 import sys
 import os.path
-import subprocess
+import logging
 import tarfile
 import codecs
+import requests
+import gnupg
 
-# Get JSON events from file
-def get_events(filename, recipient, passphrase_file):
-    # Untar and then read the output
-    if filename.endswith(".json.tar.gz"):
-        tar = tarfile.open(filename)
-        reader = codecs.getreader("utf-8")
-        for member in tar.getmembers():
-            memberfile = tar.extractfile(member)
-            f = reader(memberfile)
-            return [line.rstrip('\n') for line in f]
+GPG_HOME_FOLDER = "/root/.gnupg"
+UNENCRYPTED_LOGS_FOLDER = "/project/data/logs/http"
 
-    else:
-        with open(filename) as f:
-            # Just read the file
-            if filename.endswith(".json"):
-                return [line.rstrip('\n') for line in f]
+def strip_newlines(file):
+    return list(line.rstrip('\n') for line in file)
 
-            # Decrypt and then read the output
-            elif filename.endswith(".json.gpg"):
-                subproc = subprocess.run(["/usr/bin/gpg", "--decrypt", "--recipient", recipient, "--passphrase-file", passphrase_file, "--trust-model", "always", "--batch", "--pinentry-mode", "loopback"],
-                                         stdin=f, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                print(subproc.stderr.decode("utf-8"))
-                subproc.check_returncode()
-                return [line.rstrip('\n') for line in subproc.stdout.decode("utf-8").splitlines()]
+def yield_files_from_filename(file_path, gpg_instance, passphrase):
+    """ Yields file-like objects containing JSON.
+        Since this functions also takes archive files, one filename can potentially yield multiple file-like objects
+    """
+    filename = os.path.split(file_path)[1]
+    if filename.endswith(".json.tar.gz"): # Untar and then read the output
+        with tarfile.open(file_path) as tar:
+            reader = codecs.getreader("utf-8")
+            for member in tar.getmembers():
+                memberfile = tar.extractfile(member)
+                yield reader(memberfile)
+    elif filename.endswith(".json"):
+        with open(file_path) as f:
+            yield f
+    elif filename.endswith(".json.gpg"): # Decrypt and then read the output
+        unencrypted_filename = filename.replace('.json.gpg', '.json')
+        output_path = os.path.join(UNENCRYPTED_LOGS_FOLDER, unencrypted_filename)
+        with open(file_path, "rb") as f:
+            logging.info("Starting decryption for {} ...".format(file_path))
+            decryption_status = gpg_instance.decrypt_file(f, passphrase=passphrase, always_trust=True, output=output_path)
+            if not decryption_status.ok:
+                raise Exception("GPG Decryption failed: {}".format(decryption_status.status))
+            yield yield_files_from_filename(output_path, gpg_instance, passphrase)
 
 # Check input
 if len(sys.argv) < 6:
@@ -52,25 +57,29 @@ index = sys.argv[4]
 command = '{{ "index" : {{ "_index" : "{0:s}" }} }}'.format(index)
 def to_bulk_query(events):
     for event in events:
-        yield command
-        yield event
+        yield command + '\n'
+        yield event + '\n'
+
+logging.info("Initializing Python gpg")
+gpg = gnupg.GPG(gnupghome=GPG_HOME_FOLDER)
 
 # Send input to Bulk API file-per-file
 for filename in sys.argv[5:]:
-    # Get events in file
-    events = get_events(filename, sys.argv[1], sys.argv[2])
+    print("Ingesting file: {0:s}".format(filename))
+    try:
+        for file in yield_files_from_filename(filename, gpg, sys.argv[2]):
+            bulkdata = to_bulk_query(file)
 
-    if events:
-        # Format events for Elasticsearch
-        bulkdata = '\n'.join([line for line in to_bulk_query(events)]) + '\n'
-        bulkdata = bulkdata.encode(encoding='utf-8')
+            # Send request to Bulk API
+            headers = { 'content-type' : 'application/json' }
+            print("Started streaming")
 
-        # Send request to Bulk API
-        headers = { 'content-type' : 'application/json' }
-        r = requests.post("{0:s}/_bulk".format(url), data=bulkdata, headers=headers)
-
-        # Print result
-        print("Ingested file: {0:s}".format(filename))
-        print("Response: {0:d}".format(r.status_code))
-    else:
+            response = requests.post("{0:s}/_bulk".format(url), data=bulkdata, headers=headers, timeout=10)
+            response.raise_for_status()
+            
+            # Print result
+            print("Ingested file: {0:s}".format(filename))
+            print("Response: {0:d}".format(response.status_code))
+    except Exception as e:
         print("Skipped file: {0:s}".format(filename))
+        raise e


### PR DESCRIPTION
The decryption process now no longer loads an entire log-file in memory and writes the unencrypted file to disk. Also contains an overhaul which makes a better distinction between pre-processing and ingestion-code.

Since the contents of the `Dockerfile` have been modified, please don't forget to update the `redpencil/app-http-logger-visualize-scripts`-image.

Future work: evaluate the comment on L57-58 regarding ingestion-speed.