### PR TITLE
Always prompt for passphrase

### DIFF
--- a/scripts/visualize-scripts/config.json
+++ b/scripts/visualize-scripts/config.json
@@ -5,7 +5,7 @@
       "documentation": {
         "command": "http",
         "description": "Decrypt and import HTTP logs into Elasticsearch. Expects a private key in a file in the './keys' folder named 'gpg.key', and encrypted files in the './data/encrypted/http' directory.  If password is empty, it will be requested on the terminal.",
-        "arguments": ["recipient", "password", "threads:1", "batch-size:1000"]
+        "arguments": ["recipient", "threads:1", "batch-size:1000"]
       },
       "environment": {
         "image": "redpencil/app-http-logger-visualize-scripts:1.1.0",

--- a/scripts/visualize-scripts/http.sh
+++ b/scripts/visualize-scripts/http.sh
@@ -6,22 +6,18 @@ chmod go-rwx /root/.gnupg/
 echo "auto-expand-secmem 0x30000" > /root/.gnupg/gpg-agent.conf
 
 RECIPIENT=$1
-PASSPHRASE=$2
 
-if ["$PASSPHRASE" -eq ""]
-then
-   echo ""
-   echo -n "Enter key passphrase: "
-   read -r -s PASSPHRASE
-   echo ""
-fi
+echo ""
+echo -n "Enter key passphrase: "
+read -r -s PASSPHRASE
+echo ""
 
 # Add the key and unlock it
 echo "$PASSPHRASE" | gpg --batch --import --pinentry-mode loopback /project/keys/gpg.key
 
 ES_INDEX="http-log"
-BATCH_SIZE=${4:-1000} # fallback to default: 1000
-THREADS=${3:-1}
+BATCH_SIZE=${3:-1000} # fallback to default: 1000
+THREADS=${2:-1}
 echo "Going to import HTTP logs in Elasticsearch index $ES_INDEX (batch size $BATCH_SIZE) (parallel $THREADS)"
 
 python3 ./import-logs.py "$RECIPIENT" "$PASSPHRASE" 'http://elasticsearch:9200' "$ES_INDEX" $BATCH_SIZE $THREADS /project/data/encrypted/http/*


### PR DESCRIPTION
When using the optional arguments `threads` and `batch-size`, it was no longer possible not to specify the passphrase in the command (and being prompted for it instead).