### PR TITLE
chore: add sparqldecode filter to logstash config

### DIFF
--- a/config/logstash-http/http-file-pipeline.conf
+++ b/config/logstash-http/http-file-pipeline.conf
@@ -6,6 +6,7 @@ input {
 
 filter {
     ipmap {}
+    sparqldecode {}
 }
 
 output {

--- a/config/logstash-http/http-visualize-pipeline.conf
+++ b/config/logstash-http/http-visualize-pipeline.conf
@@ -6,6 +6,7 @@ input {
 
 filter {
     ipmap {}
+    sparqldecode {}
 }
 
 output {


### PR DESCRIPTION
Since the functionality to decode SPARQL queries has been removed from the ipmap filter, we now need to explicitly add the sparqldecode filter to the config. Now it's finally used :)

Related service PR:
- [ ] https://github.com/redpencilio/http-logger-logstash-service/pull/5