### PR TITLE
Make logstash restart on out of memory

### DIFF
--- a/docker-compose.encrypt.yml
+++ b/docker-compose.encrypt.yml
@@ -12,7 +12,7 @@ services:
       - ./data/logs/http:/usr/share/logstash/data:rw
     environment:
       LOGFILE_FORMAT_STRING: '/usr/share/logstash/data/http-log-%{+YYYY-MM-dd-HH}.json'
-      LS_JAVA_OPTS: "-Xms512m -Xmx512m"
+      LS_JAVA_OPTS: "-Xms512m -Xmx512m -XX:+ExitOnOutOfMemoryError"
     logging: *default-logging
   stats-logstash:
     volumes:
@@ -20,7 +20,7 @@ services:
       - ./data/logs/stats:/usr/share/logstash/data:rw
     environment:
       LOGFILE_FORMAT_STRING: '/usr/share/logstash/data/stats-%{+YYYY-MM-dd-HH}.json'
-      LS_JAVA_OPTS: "-Xms512m -Xmx512m"
+      LS_JAVA_OPTS: "-Xms512m -Xmx512m -XX:+ExitOnOutOfMemoryError"
     logging: *default-logging
   encrypt:
     image: redpencil/file-encryption-service:1.1.0

--- a/docker-compose.live.yml
+++ b/docker-compose.live.yml
@@ -10,9 +10,11 @@ services:
     volumes:
       - ./config/logstash-http/output-visualize.conf:/usr/share/logstash/pipeline/output-visualize.conf:ro
     environment:
-      LS_JAVA_OPTS: "-Xms256m -Xmx256m"
+      LS_JAVA_OPTS: "-Xms256m -Xmx256m -XX:+ExitOnOutOfMemoryError"
     logging: *default-logging
   stats-logstash:
     volumes:
       - ./config/logstash-stats/output-visualize.conf:/usr/share/logstash/pipeline/output-visualize.conf:ro
+    environment:
+      LS_JAVA_OPTS: "-XX:+ExitOnOutOfMemoryError"
     logging: *default-logging


### PR DESCRIPTION
When logstash would run out of memory, it would crash but not restart.
This JVM option will make logstash restart when it runs out of memory.